### PR TITLE
Change OAL namespace

### DIFF
--- a/src/oal21.xsd
+++ b/src/oal21.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsd:schema targetNamespace="https://github.com/openastronomylog/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="https://github.com/openastronomylog/openastronomylog" version="2.1">
+<xsd:schema targetNamespace="http://groups.google.com/group/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="http://groups.google.com/group/openastronomylog" version="2.1">
 	<!-- 
 	    Schema for documentation and exchange of observations of astronomical objects. 
 		 Author: Thomas Pfleger 

--- a/src/openastronomylog21/ext_DeepSky.xsd
+++ b/src/openastronomylog21/ext_DeepSky.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsd:schema targetNamespace="https://github.com/openastronomylog/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="https://github.com/openastronomylog/openastronomylog" version="2.1">
+<xsd:schema targetNamespace="http://groups.google.com/group/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="http://groups.google.com/group/openastronomylog" version="2.1">
 	<!-- 
 	    Schema for documentation and exchange of observations of astronomical objects. 
 		 Authors: Thomas Pfleger 

--- a/src/openastronomylog21/ext_Imaging.xsd
+++ b/src/openastronomylog21/ext_Imaging.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsd:schema targetNamespace="https://github.com/openastronomylog/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="https://github.com/openastronomylog/openastronomylog" version="2.1">
+<xsd:schema targetNamespace="http://groups.google.com/group/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="http://groups.google.com/group/openastronomylog" version="2.1">
 	<!-- 
 	    Schema for documentation and exchange of observations of astronomical objects. 
 		 Authors: Thomas Pfleger 

--- a/src/openastronomylog21/ext_SolarSystem.xsd
+++ b/src/openastronomylog21/ext_SolarSystem.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsd:schema targetNamespace="https://github.com/openastronomylog/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="https://github.com/openastronomylog/openastronomylog" version="2.1">
+<xsd:schema targetNamespace="http://groups.google.com/group/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="http://groups.google.com/group/openastronomylog" version="2.1">
 	<!-- 
 	    Schema for documentation and exchange of observations of astronomical objects. 
 		 Authors: Thomas Pfleger 

--- a/src/openastronomylog21/ext_VariableStars.xsd
+++ b/src/openastronomylog21/ext_VariableStars.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsd:schema targetNamespace="https://github.com/openastronomylog/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="https://github.com/openastronomylog/openastronomylog" version="2.1">
+<xsd:schema targetNamespace="http://groups.google.com/group/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="http://groups.google.com/group/openastronomylog" version="2.1">
 	<!-- 
 	    Schema for documentation and exchange of observations of astronomical objects. 
 		 Authors: Dirk Lehmann

--- a/src/openastronomylog21/oal_Base.xsd
+++ b/src/openastronomylog21/oal_Base.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<xsd:schema targetNamespace="https://github.com/openastronomylog/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="https://github.com/openastronomylog/openastronomylog" version="2.1">
+<xsd:schema targetNamespace="http://groups.google.com/group/openastronomylog" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oal="http://groups.google.com/group/openastronomylog" version="2.1">
 	<!-- 
 	    Schema for documentation and exchange of observations of astronomical objects. 
 		 Authors: Thomas Pfleger 

--- a/src/transforms/OAL21_to_OAL20.xsl
+++ b/src/transforms/OAL21_to_OAL20.xsl
@@ -10,7 +10,7 @@
 ]>
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-   xmlns:oal="https://github.com/openastronomylog/openastronomylog" exclude-result-prefixes="oal">
+   xmlns:oal="http://groups.google.com/group/openastronomylog" exclude-result-prefixes="oal">
 	<xsl:output method="xml" version="1.0" encoding="ISO-8859-1" indent="yes" media-type="text/xml"/>
    
 	<!-- Copy a session to the output, omitting the 'image' element(s) -->
@@ -33,9 +33,9 @@
 
    <xsl:template match="/">
       <xsl:text disable-output-escaping="yes"><![CDATA[<oal:observations version="2.0"]]></xsl:text>
-      <xsl:text disable-output-escaping="yes"><![CDATA[ xmlns:oal="https://github.com/openastronomylog/openastronomylog"]]></xsl:text>
+      <xsl:text disable-output-escaping="yes"><![CDATA[ xmlns:oal="http://groups.google.com/group/openastronomylog"]]></xsl:text>
       <xsl:text disable-output-escaping="yes"><![CDATA[ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"]]></xsl:text>
-      <xsl:text disable-output-escaping="yes"><![CDATA[ xsi:schemaLocation="https://github.com/openastronomylog/openastronomylog oal20.xsd">]]></xsl:text>&cr;
+      <xsl:text disable-output-escaping="yes"><![CDATA[ xsi:schemaLocation="http://groups.google.com/group/openastronomylog oal20.xsd">]]></xsl:text>&cr;
 
       <xsl:text disable-output-escaping="yes"><![CDATA[<observers>]]></xsl:text>&cr;
       <xsl:for-each select="//observers/observer">


### PR DESCRIPTION
Change OAL namespace back to groups.google.com by request of developer community.